### PR TITLE
fix(test): add spock library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 dependencies {
+    testImplementation "io.micronaut.test:micronaut-test-spock"
+    testImplementation("org.spockframework:spock-core") {
+        exclude group: "org.codehaus.groovy", module: "groovy-all"
+    }
     implementation 'com.github.oshi:oshi-core:6.4.4'
     implementation 'org.projectlombok:lombok:1.18.28'
     implementation 'info.picocli:picocli'

--- a/src/test/groovy/com/github/jonathan/zollinger/MicrofetchCliSpec.groovy
+++ b/src/test/groovy/com/github/jonathan/zollinger/MicrofetchCliSpec.groovy
@@ -8,45 +8,20 @@ import io.micronaut.context.annotation.Value
 import io.micronaut.context.env.Environment
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import oshi.SystemInfo
-import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
 
 @MicronautTest
 class MicrofetchCliSpec extends Specification {
-    @Shared
-    final PrintStream originalOut = System.out
-    @Shared
-    final PrintStream originalErr = System.err
-
-    @Shared
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
-    ByteArrayOutputStream errStream = new ByteArrayOutputStream()
-
-    @Shared
-    @AutoCleanup
-    ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)
 
     @Shared
     @Value('${micronaut.application.version}')
     String version = "0.0.1"
 
-    def setup() {
-        outputStream.reset()
-        errStream.reset()
-        System.setOut(new PrintStream(outputStream))
-        System.setErr(new PrintStream(errStream))
-    }
-
-    def cleanup() {
-        System.setOut(originalOut)
-        System.setErr(originalErr)
-    }
-
     def "query version without error"() {
         when:
         String[] args = new String[]{versionArg}
-        PicocliRunner.run(Microfetch, ctx, args)
+        def (outputStream, errStream) = executeCommand(args)
 
         then:
         outputStream.toString() == "[Microfetch Version $version]${System.lineSeparator()}"
@@ -65,7 +40,7 @@ class MicrofetchCliSpec extends Specification {
 
         when: "using '#flag' flag"
         String[] args = new String[]{flag, (distro as AsciiEnum).name().toLowerCase()}
-        PicocliRunner.run(Microfetch, ctx, args)
+        def (outputStream, errStream) = executeCommand(args)
 
         then: "no error output and output contains appropriate distro"
         !outputStream.toString().isBlank()
@@ -82,10 +57,11 @@ class MicrofetchCliSpec extends Specification {
 
         when: "using '#flag' flag"
         String[] args = new String[]{flag, distro.toLowerCase()}
-        PicocliRunner.run(Microfetch, ctx, args)
+        def (outputStream, errStream) = executeCommand(args)
 
         then: "no error output and output contains linux distro"
         !outputStream.toString().isBlank()
+        !outputStream.toString().contains("Exception")
         outputStream.toString().contains(AsciiEnum.LINUX.toString())
         errStream.toString().isBlank()
 
@@ -100,16 +76,35 @@ class MicrofetchCliSpec extends Specification {
         String os = new SystemInfo().operatingSystem.getFamily()
 
         when: "perform query with no args"
-        PicocliRunner.run(Microfetch, ctx, new String[]{})
+        def (outputStream, errStream) = executeCommand("")
 
         then: "no error output"
         errStream.toString().isBlank()
+        def expectedDistroArt = AsciiEnum.getEnumConstants().find {os}.toString()
 
         and: "#os distro art is returned"
-        outputStream.toString().contains(
-                AsciiEnum.getEnumConstants().find {it.name().equalsIgnoreCase(os)}.toString()
-        )
+        outputStream.toString().contains(expectedDistroArt)
 
+    }
+
+    /**
+     * Execute a command with the given arguments and return a pair of streams as stdout and stderr.
+     *
+     * This method captures the stdout and stderr, runs the command using the PicocliRunner,
+     * and then returns the output streams.
+     *
+     * @param args the arguments to pass to the command
+     * @return an array containing the output stream and error stream
+     */
+    String[] executeCommand(String... args) {
+        OutputStream out = new ByteArrayOutputStream()
+        OutputStream err = new ByteArrayOutputStream()
+        System.setOut(new PrintStream(out))
+        System.setErr(new PrintStream(out))
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            PicocliRunner.run(Microfetch.class, ctx, args)
+        }
+        return new String[]{out, err}
     }
 }
 


### PR DESCRIPTION
fix #26
simplify test process

CI SHOULD fail with this because of prior bugs not causing test failures. this should expose that (maybe more) bug